### PR TITLE
fixed format to query managedclusterviews

### DIFF
--- a/src/v1/connectors/kube.js
+++ b/src/v1/connectors/kube.js
@@ -247,7 +247,7 @@ export default class KubeConnector {
       spec: {
         scope: {
           name: resourceName,
-          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}.${version}`,
+          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
         },
       },
     };


### PR DESCRIPTION
Signed-off-by: Chunxi Luo chuluo@redhat.com

https://github.com/open-cluster-management/grc-ui-api/pull/135

So in the source code, we will first visit this line

https://github.com/open-cluster-management/multicloud-operators-foundation/blob/5a7decb805ccbc17e49817ce553f9b52bbdafb0c/pkg/utils/rest/mapper.go#L75

then this line

https://github.com/kubernetes/apimachinery/blob/master/pkg/runtime/schema/group_version.go#L51

if there is `Kind.version` format string, we will get Group = version here https://github.com/kubernetes/apimachinery/blob/master/pkg/runtime/schema/group_version.go#L82

Correct me if I'm wrong